### PR TITLE
make a few methods static, add set_blocksize helper

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ os:
 language: java
 before_install: 
   - export LD_LIBRARY_PATH=/usr/local/lib
-  - echo "yes" | sudo add-apt-repository ppa:kalakris/cmake
   - sudo apt-get update -qq
   - sudo apt-get install cmake
   - cd jblosc

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,20 +1,15 @@
 os:
   - linux
-#  - osx
 language: java
-before_install: 
-  - export LD_LIBRARY_PATH=/usr/local/lib
-  - sudo apt-get update -qq
-  - sudo apt-get install cmake
+before_install:
+  - export LD_LIBRARY_PATH=$HOME/lib
+  - ./travis-setup.sh
   - cd jblosc
-  - git clone https://github.com/Blosc/c-blosc.git
-  - cd c-blosc
-  - rm -rf build
-  - mkdir build
-  - cd build
-  - sudo cmake -DCMAKE_GENERATOR_PLATFORM=x64 ..
-  - sudo cmake --build . --target install
-  - cd ../..
 
 install:
   - mvn install -B -V
+
+cache:
+  directories:
+  - $HOME/.m2/repository
+  - $HOME/lib

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 os:
   - linux
+sudo: false
 language: java
 before_install:
   - export LD_LIBRARY_PATH=$HOME/lib

--- a/jblosc/pom.xml
+++ b/jblosc/pom.xml
@@ -10,6 +10,11 @@
     <name>JBlosc</name>
     <description>Blosc Java Interface</description>
     <url>https://github.com/Blosc/JBlosc</url>
+    <scm>
+        <connection>scm:git:git://github.com/Blosc/JBlosc.git</connection>
+        <developerConnection>scm:git:git@github.com:Blosc/JBlosc.git</developerConnection>
+        <url>https://github.com/Blosc/JBlosc</url>
+    </scm>
     <licenses>
         <license>
             <name>BSD License for jblosc</name>
@@ -39,6 +44,84 @@
         <project.build.sourceEncoding>ISO-8859-1</project.build.sourceEncoding>
     </properties>
 
+    <profiles>
+        <profile>
+            <id>release</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-javadoc-plugin</artifactId>
+                        <version>2.9.1</version>
+                        <executions>
+                            <execution>
+                                <id>attach-javadocs</id>
+                                <goals>
+                                    <goal>jar</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-source-plugin</artifactId>
+                        <version>2.1.2</version>
+                        <configuration>
+                            <attach>true</attach>
+                        </configuration>
+                        <executions>
+                            <execution>
+                                <id>create-source-jar</id>
+                                <goals>
+                                    <goal>jar-no-fork</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-gpg-plugin</artifactId>
+                        <version>1.1</version>
+                        <executions>
+                            <execution>
+                                <id>sign-artifacts</id>
+                                <phase>verify</phase>
+                                <goals>
+                                    <goal>sign</goal>
+                                </goals>
+                                <configuration>
+                                    <useAgent>true</useAgent>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.sonatype.plugins</groupId>
+                        <artifactId>nexus-staging-maven-plugin</artifactId>
+                        <version>1.6.2</version>
+                        <extensions>true</extensions>
+                        <configuration>
+                            <serverId>ossrh</serverId>
+                            <nexusUrl>https://oss.sonatype.org/</nexusUrl>
+                            <autoReleaseAfterClose>true</autoReleaseAfterClose>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
+
+    <distributionManagement>
+        <snapshotRepository>
+            <id>ossrh</id>
+            <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+        </snapshotRepository>
+        <repository>
+            <id>ossrh</id>
+            <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
+        </repository>
+    </distributionManagement>
+
     <dependencies>
         <dependency>
             <groupId>junit</groupId>
@@ -53,7 +136,8 @@
     </dependencies>
 
     <build>
-        <sourceDirectory>src</sourceDirectory>
+        <sourceDirectory>src/main/java</sourceDirectory>
+        <testSourceDirectory>src/test/java</testSourceDirectory>
         <plugins>
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>

--- a/jblosc/pom.xml
+++ b/jblosc/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>org.blosc</groupId>
     <artifactId>jblosc</artifactId>
-    <version>1.0.1.dev</version>
+    <version>1.0.1-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>JBlosc</name>

--- a/jblosc/src/main/java/org/blosc/IBloscDll.java
+++ b/jblosc/src/main/java/org/blosc/IBloscDll.java
@@ -75,6 +75,8 @@ public class IBloscDll {
 
 	public static native int blosc_get_blocksize();
 
+	public static native void blosc_set_blocksize(NativeLong blocksize);
+
 	public static native void blosc_destroy();
 
 }

--- a/jblosc/src/main/java/org/blosc/JBlosc.java
+++ b/jblosc/src/main/java/org/blosc/JBlosc.java
@@ -135,7 +135,7 @@ public class JBlosc {
 	}
 
 	/**
-	 * Call to the JNA blosc_free_resources throws an uncheked RuntimeException
+	 * Call to the JNA blosc_free_resources throws an unchecked RuntimeException
 	 * if there are problems freeing resources
 	 */
 	public void freeResources() {
@@ -151,6 +151,10 @@ public class JBlosc {
 	 */
 	public int getBlocksize() {
 		return IBloscDll.blosc_get_blocksize();
+	}
+
+	static public void setBlocksize(long blocksize) {
+		IBloscDll.blosc_set_blocksize(new NativeLong(blocksize));
 	}
 
 	public BufferSizes cbufferSizes(ByteBuffer cbuffer) {
@@ -172,7 +176,7 @@ public class JBlosc {
 		}
 	}
 
-	private void checkExit(int w) {
+	private static void checkExit(int w) {
 		if (w == 0) {
 			throw new RuntimeException("Compressed size larger then dest length");
 		}
@@ -200,7 +204,7 @@ public class JBlosc {
 		return IBloscDll.blosc_decompress(src, dest, new NativeLong(destSize));
 	}
 
-	public int compressCtx(int compressionLevel, int shuffleType, int typeSize, ByteBuffer src, long srcLength,
+	public static int compressCtx(int compressionLevel, int shuffleType, int typeSize, ByteBuffer src, long srcLength,
 			ByteBuffer dest, long destLength, String compressorName, int blockSize, int numThreads) {
 		src.position(0);
 		dest.position(0);
@@ -213,7 +217,7 @@ public class JBlosc {
 		return w;
 	}
 
-	public int decompressCtx(Buffer src, Buffer dest, long destSize, int numThreads) {
+	public static int decompressCtx(Buffer src, Buffer dest, long destSize, int numThreads) {
 		src.position(0);
 		dest.position(0);
 		return IBloscDll.blosc_decompress_ctx(src, dest, new NativeLong(destSize), numThreads);

--- a/jblosc/src/test/java/org/blosc/BloscTest.java
+++ b/jblosc/src/test/java/org/blosc/BloscTest.java
@@ -69,7 +69,7 @@ public class BloscTest {
 					.println("Working with compressor " + compname + " (code " + compcode + ") " + ci[0] + " " + ci[1]);
 			long startTime = System.currentTimeMillis();
 			ByteBuffer o = ByteBuffer.allocateDirect(SIZE * 2 + JBlosc.OVERHEAD);
-			// int s = jb.compressCtx(5, Shuffle.BYTE_SHUFFLE,
+			// int s = JBlosc.compressCtx(5, Shuffle.BYTE_SHUFFLE,
 			// PrimitiveSizes.DOUBLE_FIELD_SIZE, b, SIZE * 8, o,
 			// SIZE * 8 + JBlosc.OVERHEAD, compname, 0, 1);
 			jb.compress(5, Shuffle.BYTE_SHUFFLE, PrimitiveSizes.CHAR_FIELD_SIZE, b,
@@ -199,11 +199,11 @@ public class BloscTest {
 		ByteBuffer ibb = Util.array2ByteBuffer(data);
 		JBlosc jb = new JBlosc();
 		ByteBuffer obb = ByteBuffer.allocateDirect(ibb.limit() + JBlosc.OVERHEAD);
-		jb.compressCtx(5, Shuffle.BYTE_SHUFFLE, PrimitiveSizes.DOUBLE_FIELD_SIZE, ibb, ibb.limit(), obb, obb.limit(),
-				"blosclz", 0, 4);
+		JBlosc.compressCtx(5, Shuffle.BYTE_SHUFFLE, PrimitiveSizes.DOUBLE_FIELD_SIZE, ibb, ibb.limit(), obb, obb.limit(),
+									 "blosclz", 0, 4);
 		printRatio(jb, "Double", obb);
 		ByteBuffer abb = ByteBuffer.allocateDirect(ibb.limit());
-		jb.decompressCtx(obb, abb, abb.limit(), 4);
+		JBlosc.decompressCtx(obb, abb, abb.limit(), 4);
 		double[] data_again = Util.byteBufferToDoubleArray(abb);
 		jb.destroy();
 		assertArrayEquals(data, data_again, (float) 0);

--- a/travis-setup.sh
+++ b/travis-setup.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+set -ex
+
+if [ -e "$HOME"/lib/libblosc.so ]; then
+  echo "Found existing libblosc; skipping install:"
+  ls -l "$HOME"/lib/*blosc*
+  exit 0
+fi
+
+sudo apt-get update -qq
+sudo apt-get install cmake
+git clone https://github.com/Blosc/c-blosc.git
+cd c-blosc
+rm -rf build
+mkdir build
+cd build
+cmake -DCMAKE_INSTALL_PREFIX="$HOME" ..
+cmake --build . --target install
+

--- a/travis-setup.sh
+++ b/travis-setup.sh
@@ -8,8 +8,6 @@ if [ -e "$HOME"/lib/libblosc.so ]; then
   exit 0
 fi
 
-sudo apt-get update -qq
-sudo apt-get install cmake
 git clone https://github.com/Blosc/c-blosc.git
 cd c-blosc
 rm -rf build


### PR DESCRIPTION
also:
- cache c-blosc install in homedir on travis
- fix up POM for maven central deployment

I released a fork from [lasersonlab/JBlosc/](https://github.com/lasersonlab/JBlosc/) as [`org.lasersonlab:jblosc:1.0.1`](https://oss.sonatype.org/content/repositories/releases/org/lasersonlab/jblosc/1.0.1/) for my immediate use downstream, but these are the upstream-worthy bits